### PR TITLE
feat/rosetta-sdk-0.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A sample of this configuration can be found in `config.local.yaml`.
 rosetta:
  host: "0.0.0.0"
  port: 8080
- version: "1.4.9"
+ version: "1.4.10"
  middleware_version: "0.0.1"
 
 networks:

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ These are the following lists of APIs not supported by Zilliqa blockchain:
 ## How to test
 Install the latest rosetta-cli from https://github.com/coinbase/rosetta-cli.
 
-At the time of writing, we are using [rosetta-cli v0.6.7](https://github.com/coinbase/rosetta-cli/releases/tag/v0.6.7).
+At the time of writing, we are using [rosetta-cli v0.7.1](https://github.com/coinbase/rosetta-cli/releases/tag/v0.7.1).
 
 To begin testing:
 1. cd into zilliqa-rosetta folder
@@ -191,6 +191,64 @@ Note: The `mainnet_config.json` specifically **disables** historical balance loo
 
 For **testnet** tests, we begin the test from Block 1600000. Some of our much earlier testnet blocks, e.g. Block 270000++, cannot be fetch. Hence, it is recommended to skip certain sections of the testnet blocks.
 
+### End Conditions
+
+The end conditions for `check:data` on testnet is set to 600 seconds. Once the duration is up, the tests will terminate and a report would be displayed:
+```
+Success: Duration End Condition [Seconds: 600]
+
++--------------------+--------------------------------+------------+
+|  CHECK:DATA TESTS  |          DESCRIPTION           |   STATUS   |
++--------------------+--------------------------------+------------+
+| Request/Response   | Rosetta implementation         | PASSED     |
+|                    | serviced all requests          |            |
++--------------------+--------------------------------+------------+
+| Response Assertion | All responses are correctly    | PASSED     |
+|                    | formatted                      |            |
++--------------------+--------------------------------+------------+
+| Block Syncing      | Blocks are connected into a    | PASSED     |
+|                    | single canonical chain         |            |
++--------------------+--------------------------------+------------+
+| Balance Tracking   | Account balances did not go    | NOT TESTED |
+|                    | negative                       |            |
++--------------------+--------------------------------+------------+
+| Reconciliation     | No balance discrepencies were  | NOT TESTED |
+|                    | found between computed and     |            |
+|                    | live balances                  |            |
++--------------------+--------------------------------+------------+
+
++--------------------------+--------------------------------+-----------+
+|     CHECK:DATA STATS     |          DESCRIPTION           |   VALUE   |
++--------------------------+--------------------------------+-----------+
+| Blocks                   | # of blocks synced             |    101524 |
++--------------------------+--------------------------------+-----------+
+| Orphans                  | # of blocks orphaned           |         0 |
++--------------------------+--------------------------------+-----------+
+| Transactions             | # of transaction processed     |      5930 |
++--------------------------+--------------------------------+-----------+
+| Operations               | # of operations processed      |     10674 |
++--------------------------+--------------------------------+-----------+
+| Accounts                 | # of accounts seen             |         0 |
++--------------------------+--------------------------------+-----------+
+| Active Reconciliations   | # of reconciliations performed |         0 |
+|                          | after seeing an account in a   |           |
+|                          | block                          |           |
++--------------------------+--------------------------------+-----------+
+| Inactive Reconciliations | # of reconciliations performed |         0 |
+|                          | on randomly selected accounts  |           |
++--------------------------+--------------------------------+-----------+
+| Exempt Reconciliations   | # of reconciliation failures   |         0 |
+|                          | considered exempt              |           |
++--------------------------+--------------------------------+-----------+
+| Failed Reconciliations   | # of reconciliation failures   |         0 |
++--------------------------+--------------------------------+-----------+
+| Skipped Reconciliations  | # of reconciliations skipped   |         0 |
++--------------------------+--------------------------------+-----------+
+| Reconciliation Coverage  | % of accounts that have been   | 0.000000% |
+|                          | reconciled                     |           |
++--------------------------+--------------------------------+-----------+
+```
+
 ### Testing Construction API
 
 ```
@@ -210,12 +268,48 @@ Fund the stated `zil` address with **at least** the (value + gas fees), e.g. the
 
 Next, `rosetta-cli` would create a payment transaction from the created address to another created address.
 
-Lastly, the test is completed if you see this:
+
+### End Conditions
+
+The end conditions for `check:construction` is set to:
 ```
-[STATS] Transactions Confirmed: 360 (Created: 370, In Progress: 1, Stale: 6, Failed: 9) Addresses Created: 99
+  "create_account": 10,
+  "transfer": 10
 ```
 
-The construction API test would continue until the funds of the created accounts are emptied. You may halt the test at any time.
+Once the tests created 10 new accounts and peform a transfer operation on each account, the tests will terminate and a report would be displayed:
+```
+Success: {"create_account":10,"transfer":10}
+
++--------------------------+--------------------------------+-------+
+| CHECK:CONSTRUCTION STATS |          DESCRIPTION           | VALUE |
++--------------------------+--------------------------------+-------+
+| Addresses Created        | # of addresses created         |    11 |
++--------------------------+--------------------------------+-------+
+| Transactions Created     | # of transactions created      |    11 |
++--------------------------+--------------------------------+-------+
+| Stale Broadcasts         | # of broadcasts missing after  |     0 |
+|                          | stale depth                    |       |
++--------------------------+--------------------------------+-------+
+| Transactions Confirmed   | # of transactions seen         |    10 |
+|                          | on-chain                       |       |
++--------------------------+--------------------------------+-------+
+| Failed Broadcasts        | # of transactions that         |     0 |
+|                          | exceeded broadcast limit       |       |
++--------------------------+--------------------------------+-------+
++------------------------------+-------+
+| CHECK:CONSTRUCTION WORKFLOWS | COUNT |
++------------------------------+-------+
+| request_funds                |     0 |
++------------------------------+-------+
+| create_account               |    11 |
++------------------------------+-------+
+| transfer                     |    10 |
++------------------------------+-------+
+| return_funds                 |     0 |
++------------------------------+-------+
+```
+
 
 ## License
 

--- a/config.local.yaml
+++ b/config.local.yaml
@@ -1,7 +1,7 @@
 rosetta:
  host: "0.0.0.0"
  port: 8080
- version: "1.4.9"
+ version: "1.4.10"
  middleware_version: "0.0.1"
 
 networks:

--- a/config/config.go
+++ b/config/config.go
@@ -185,10 +185,10 @@ var (
 	}
 )
 
-const OpTypeTransfer = "transfer"
-const OpTypeContractDeployment = "contract_deployment"
-const OpTypeContractCall = "contract_call"
-const OpTypeContractCallTransfer = "contract_call_transfer"
+const OpTypeTransfer = "TRANSFER"
+const OpTypeContractDeployment = "CONTRACT_DEPLOYMENT"
+const OpTypeContractCall = "CONTRACT_CALL"
+const OpTypeContractCallTransfer = "CONTRACT_CALL_TRANSFER"
 
 type Rosetta struct {
 	Host string

--- a/config/mainnet_config.json
+++ b/config/mainnet_config.json
@@ -5,7 +5,7 @@
     },
     "online_url": "http://localhost:8080",
     "data_directory": "data/",
-    "http_timeout": 10,
+    "http_timeout": 300,
     "tip_delay": 300,
     "data": {
      "historical_balance_enabled": false,

--- a/config/testnet_config.json
+++ b/config/testnet_config.json
@@ -5,7 +5,7 @@
  },
  "online_url": "http://localhost:8080",
  "data_directory": "data/",
- "http_timeout": 10,
+ "http_timeout": 300,
  "tip_delay": 300,
  "construction": {
     "offline_url": "http://localhost:8080",

--- a/config/testnet_config.json
+++ b/config/testnet_config.json
@@ -18,6 +18,10 @@
     "block_broadcast_limit": 100,
     "rebroadcast_all": false,
     "constructor_dsl_file": "zilliqa.ros",
+    "end_conditions": {
+       "create_account": 10,
+       "transfer": 10
+    },
     "prefunded_accounts": [
      {
       "privkey": "b46e482c0d07be65138d734e15b9280fe619ebf571f4e656d744c591f9515022",
@@ -42,7 +46,7 @@
   "start_index": 2152500,
   "balance_tracking_disabled": true,
   "end_conditions": {
-   "tip": true
+   "duration": 600
   }
  }
 }

--- a/config/zilliqa.ros
+++ b/config/zilliqa.ros
@@ -73,7 +73,7 @@ transfer(1){
     transfer.operations = [
       {
         "operation_identifier":{"index":0},
-        "type":"transfer",
+        "type":"TRANSFER",
         "account":{{sender.account_identifier}},
         "amount":{
           "value":{{sender_amount}},
@@ -82,7 +82,7 @@ transfer(1){
       },
       {
         "operation_identifier":{"index":1},
-        "type":"transfer",
+        "type":"TRANSFER",
         "account":{{recipient.account_identifier}},
         "amount":{
           "value":{{recipient_amount}},
@@ -116,7 +116,7 @@ return_funds(1){
     transfer.operations = [
       {
         "operation_identifier":{"index":0},
-        "type":"transfer",
+        "type":"TRANSFER",
         "account":{{sender.account_identifier}},
         "amount":{
           "value":{{sender_amount}},
@@ -125,7 +125,7 @@ return_funds(1){
       },
       {
         "operation_identifier":{"index":1},
-        "type":"transfer",
+        "type":"TRANSFER",
         "account":{{faucet}},
         "amount":{
           "value":{{available_amount}},

--- a/examples/signRosettaTransaction.js
+++ b/examples/signRosettaTransaction.js
@@ -14,7 +14,7 @@ async function sign() {
         const rawTx = zilliqa.transactions.new({
             version: bytes.pack(333, 1),
             amount: new BN(units.toQa('2', units.Units.Zil)),
-            gasLimit: Long.fromNumber(1), // normal (non-contract) transactions cost 1 gas
+            gasLimit: Long.fromNumber(50), // normal (non-contract) transactions cost 1 gas
             gasPrice: new BN(units.toQa(2000, units.Units.Li)), // the minimum gas price is 1,000 li
             toAddr: recipientAddr, // recipient address must be converted to checksum address, 
             pubKey: "02e44ef2c5c2031386faa6cafdf5f67318cc661871b0112a27458e65f37a35655e", // this determines which account is used to send the tx

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398 // indirect
 	github.com/Zilliqa/gozilliqa-sdk v1.2.1-0.20201201074141-dd0ecada1be6
 	github.com/aymerick/raymond v2.0.2+incompatible // indirect
-	github.com/coinbase/rosetta-sdk-go v0.6.7
+	github.com/coinbase/rosetta-sdk-go v0.7.0
 	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/flosch/pongo2 v0.0.0-20200529170236-5abacdfa4915 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/coinbase/rosetta-sdk-go v0.6.1 h1:aOb5qstlX0uqP9HRC7wCY+YAZDzZbS2C/i3
 github.com/coinbase/rosetta-sdk-go v0.6.1/go.mod h1:t36UuaD4p2DSXaSH9IwMasZDJ7UPxt9cQi6alS5OPTo=
 github.com/coinbase/rosetta-sdk-go v0.6.7 h1:v2fzv1cOVWB4A2QjIEcZpuh/CFwfLmX+Jd6qP3AZHN0=
 github.com/coinbase/rosetta-sdk-go v0.6.7/go.mod h1:DbkDDurZUlfMqFrWfSU3gLsLCaGDyw3Cqz/f1JWjo5U=
+github.com/coinbase/rosetta-sdk-go v0.7.0 h1:lmTO/JEpCvZgpbkOITL95rA80CPKb5CtMzLaqF2mCNg=
+github.com/coinbase/rosetta-sdk-go v0.7.0/go.mod h1:7nD3oBPIiHqhRprqvMgPoGxe/nyq3yftRmpsy29coWE=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -368,15 +370,19 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/tidwall/gjson v1.6.1/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
 github.com/tidwall/gjson v1.6.3/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
 github.com/tidwall/gjson v1.6.4/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
+github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/sjson v1.1.2/go.mod h1:SEzaDwxiPzKzNfUEO4HbYF/m4UCSJDsGgNqsS1LvdoY=
+github.com/tidwall/sjson v1.1.4/go.mod h1:wXpKXu8CtDjKAZ+3DrKY5ROCorDFahq8l0tey/Lx1fg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/tyler-smith/go-bip39 v1.0.2/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
@@ -384,6 +390,7 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vmihailenco/msgpack/v5 v5.0.0-beta.9/go.mod h1:HVxBVPUK/+fZMonk4bi1islLa8V3cfnBug0+4dykPzo=
 github.com/vmihailenco/msgpack/v5 v5.1.0/go.mod h1:C5gboKD0TJPqWDTVTtrQNfRbiBwHZGo8UTqP/9/XvLI=
+github.com/vmihailenco/msgpack/v5 v5.1.4/go.mod h1:C5gboKD0TJPqWDTVTtrQNfRbiBwHZGo8UTqP/9/XvLI=
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208/go.mod h1:IotVbo4F+mw0EzQ08zFqg7pK3FebNXpaMsRy2RT+Ees=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/main.go
+++ b/main.go
@@ -55,7 +55,13 @@ func main() {
 	// requests.
 	networkIdentifier := cfg.GetNetworkIdentifier()
 	//todo
-	asserter, err := asserter.NewServer([]string{"transfer", "contract_deployment", "contract_call", "contract_call_transfer"}, true, networkIdentifier, []string{}, false)
+	asserter, err := asserter.NewServer(
+		[]string{config.OpTypeTransfer, config.OpTypeContractDeployment, config.OpTypeContractCall, config.OpTypeContractCallTransfer},
+		true,
+		networkIdentifier,
+		[]string{},
+		false,
+		"")
 
 	if err != nil {
 		log.Fatal(err)

--- a/mainnet.config.local.yaml
+++ b/mainnet.config.local.yaml
@@ -1,7 +1,7 @@
 rosetta:
  host: "0.0.0.0"
  port: 8080
- version: "1.4.9"
+ version: "1.4.10"
  middleware_version: "0.0.1"
 
 networks:

--- a/rosetta_standalone/README.md
+++ b/rosetta_standalone/README.md
@@ -107,7 +107,7 @@ These are the following lists of APIs not supported by Zilliqa blockchain:
 ## How to test
 Install the latest rosetta-cli from https://github.com/coinbase/rosetta-cli.
 
-At the time of writing, we are using [rosetta-cli v0.6.7](https://github.com/coinbase/rosetta-cli/releases/tag/v0.6.7).
+At the time of writing, we are using [rosetta-cli v0.7.1](https://github.com/coinbase/rosetta-cli/releases/tag/v0.7.1).
 
 To begin testing:
 1. cd into zilliqa-rosetta folder
@@ -130,6 +130,64 @@ Note: The `mainnet_config.json` specifically **disables** historical balance loo
 
 For **testnet** tests, we begin the test from Block 1600000. Some of our much earlier testnet blocks, e.g. Block 270000++, cannot be fetch. Hence, it is recommended to skip certain sections of the testnet blocks.
 
+### End Conditions
+
+The end conditions for `check:data` on testnet is set to 600 seconds. Once the duration is up, the tests will terminate and a report would be displayed:
+```
+Success: Duration End Condition [Seconds: 600]
+
++--------------------+--------------------------------+------------+
+|  CHECK:DATA TESTS  |          DESCRIPTION           |   STATUS   |
++--------------------+--------------------------------+------------+
+| Request/Response   | Rosetta implementation         | PASSED     |
+|                    | serviced all requests          |            |
++--------------------+--------------------------------+------------+
+| Response Assertion | All responses are correctly    | PASSED     |
+|                    | formatted                      |            |
++--------------------+--------------------------------+------------+
+| Block Syncing      | Blocks are connected into a    | PASSED     |
+|                    | single canonical chain         |            |
++--------------------+--------------------------------+------------+
+| Balance Tracking   | Account balances did not go    | NOT TESTED |
+|                    | negative                       |            |
++--------------------+--------------------------------+------------+
+| Reconciliation     | No balance discrepencies were  | NOT TESTED |
+|                    | found between computed and     |            |
+|                    | live balances                  |            |
++--------------------+--------------------------------+------------+
+
++--------------------------+--------------------------------+-----------+
+|     CHECK:DATA STATS     |          DESCRIPTION           |   VALUE   |
++--------------------------+--------------------------------+-----------+
+| Blocks                   | # of blocks synced             |    101524 |
++--------------------------+--------------------------------+-----------+
+| Orphans                  | # of blocks orphaned           |         0 |
++--------------------------+--------------------------------+-----------+
+| Transactions             | # of transaction processed     |      5930 |
++--------------------------+--------------------------------+-----------+
+| Operations               | # of operations processed      |     10674 |
++--------------------------+--------------------------------+-----------+
+| Accounts                 | # of accounts seen             |         0 |
++--------------------------+--------------------------------+-----------+
+| Active Reconciliations   | # of reconciliations performed |         0 |
+|                          | after seeing an account in a   |           |
+|                          | block                          |           |
++--------------------------+--------------------------------+-----------+
+| Inactive Reconciliations | # of reconciliations performed |         0 |
+|                          | on randomly selected accounts  |           |
++--------------------------+--------------------------------+-----------+
+| Exempt Reconciliations   | # of reconciliation failures   |         0 |
+|                          | considered exempt              |           |
++--------------------------+--------------------------------+-----------+
+| Failed Reconciliations   | # of reconciliation failures   |         0 |
++--------------------------+--------------------------------+-----------+
+| Skipped Reconciliations  | # of reconciliations skipped   |         0 |
++--------------------------+--------------------------------+-----------+
+| Reconciliation Coverage  | % of accounts that have been   | 0.000000% |
+|                          | reconciled                     |           |
++--------------------------+--------------------------------+-----------+
+```
+
 ### Testing Construction API
 
 ```
@@ -149,12 +207,46 @@ Fund the stated `zil` address with **at least** the (value + gas fees), e.g. the
 
 Next, `rosetta-cli` would create a payment transaction from the created address to another created address.
 
-Lastly, the test is completed if you see this:
+### End Conditions
+
+The end conditions for `check:construction` is set to:
 ```
-[STATS] Transactions Confirmed: 360 (Created: 370, In Progress: 1, Stale: 6, Failed: 9) Addresses Created: 99
+  "create_account": 10,
+  "transfer": 10
 ```
 
-The construction API test would continue until the funds of the created accounts are emptied. You may halt the test at any time.
+Once the tests created 10 new accounts and peform a transfer operation on each account, the tests will terminate and a report would be displayed:
+```
+Success: {"create_account":10,"transfer":10}
+
++--------------------------+--------------------------------+-------+
+| CHECK:CONSTRUCTION STATS |          DESCRIPTION           | VALUE |
++--------------------------+--------------------------------+-------+
+| Addresses Created        | # of addresses created         |    11 |
++--------------------------+--------------------------------+-------+
+| Transactions Created     | # of transactions created      |    11 |
++--------------------------+--------------------------------+-------+
+| Stale Broadcasts         | # of broadcasts missing after  |     0 |
+|                          | stale depth                    |       |
++--------------------------+--------------------------------+-------+
+| Transactions Confirmed   | # of transactions seen         |    10 |
+|                          | on-chain                       |       |
++--------------------------+--------------------------------+-------+
+| Failed Broadcasts        | # of transactions that         |     0 |
+|                          | exceeded broadcast limit       |       |
++--------------------------+--------------------------------+-------+
++------------------------------+-------+
+| CHECK:CONSTRUCTION WORKFLOWS | COUNT |
++------------------------------+-------+
+| request_funds                |     0 |
++------------------------------+-------+
+| create_account               |    11 |
++------------------------------+-------+
+| transfer                     |    10 |
++------------------------------+-------+
+| return_funds                 |     0 |
++------------------------------+-------+
+```
 
 ## License
 

--- a/rosetta_standalone/README.md
+++ b/rosetta_standalone/README.md
@@ -58,7 +58,7 @@ If you choose to connect `Zilliqa-rosetta` to any existing Zilliqa public endpoi
 rosetta:
  host: "0.0.0.0"
  port: 8080
- version: "1.4.9"
+ version: "1.4.10"
  middleware_version: "0.0.1"
 
 networks:

--- a/router/router.go
+++ b/router/router.go
@@ -24,14 +24,15 @@ func NewBlockchainRouter(
 	accountAPIService := services.NewAccountAPIService(cfg)
 	accountAPIController := server.NewAccountAPIController(accountAPIService, asserter)
 
-	memoryPoolAPIService := services.NewMemoryPoolAPIService(cfg)
-	memoryPoolController := server.NewMempoolAPIController(memoryPoolAPIService, asserter)
+	// @deprecated
+	// memoryPoolAPIService := services.NewMemoryPoolAPIService(cfg)
+	// memoryPoolController := server.NewMempoolAPIController(memoryPoolAPIService, asserter)
 
 	blockAPIService := services.NewBlockAPIService(cfg)
 	blockAPIController := server.NewBlockAPIController(blockAPIService, asserter)
 
-	constructionAPIService := services.NewConstructionAPIService(cfg, memoryPoolAPIService)
+	constructionAPIService := services.NewConstructionAPIService(cfg)
 	ConstructionAPIController := server.NewConstructionAPIController(constructionAPIService, asserter)
 
-	return server.NewRouter(networkAPIController, accountAPIController, blockAPIController, memoryPoolController, ConstructionAPIController)
+	return server.NewRouter(networkAPIController, accountAPIController, blockAPIController, ConstructionAPIController)
 }

--- a/server/services/construction_preprocess.go
+++ b/server/services/construction_preprocess.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/Zilliqa/gozilliqa-sdk/provider"
 	rosettaUtil "github.com/Zilliqa/zilliqa-rosetta/util"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
@@ -38,7 +40,20 @@ func (c *ConstructionAPIService) ConstructionPreprocess(
 		}
 	}
 
-	preProcessResp.Options[rosettaUtil.GAS_PRICE] = rosettaUtil.GAS_PRICE_VALUE
+	api := c.Config.NodeAPI(req.NetworkIdentifier.Network)
+	rpcClient := provider.NewProvider(api)
+	minGasPrice, err := rpcClient.GetMinimumGasPrice()
+
+	if err != nil {
+		fmt.Println("error fetching min gas price")
+		return nil, &types.Error{
+			Code:      0,
+			Message:   err.Error(),
+			Retriable: true,
+		}
+	}
+
+	preProcessResp.Options[rosettaUtil.GAS_PRICE] = minGasPrice
 	preProcessResp.Options[rosettaUtil.GAS_LIMIT] = rosettaUtil.GAS_LIMIT_VALUE
 	return preProcessResp, nil
 }

--- a/server/services/construction_preprocess.go
+++ b/server/services/construction_preprocess.go
@@ -2,17 +2,16 @@ package services
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/Zilliqa/gozilliqa-sdk/provider"
 	rosettaUtil "github.com/Zilliqa/zilliqa-rosetta/util"
 	"github.com/coinbase/rosetta-sdk-go/types"
 )
 
 // ConstructionPreprocess /construction/preprocess
 // create a request to fetch metadata
-// TODO - support contract deployment and contract call operations
-// support payment operation
+// gas price is obtained from config file as this api must be available in offline mode
+// @TODO - support contract deployment and contract call operations
+// @TODO - support payment operation
 func (c *ConstructionAPIService) ConstructionPreprocess(
 	ctx context.Context,
 	req *types.ConstructionPreprocessRequest,
@@ -40,20 +39,7 @@ func (c *ConstructionAPIService) ConstructionPreprocess(
 		}
 	}
 
-	api := c.Config.NodeAPI(req.NetworkIdentifier.Network)
-	rpcClient := provider.NewProvider(api)
-	minGasPrice, err := rpcClient.GetMinimumGasPrice()
-
-	if err != nil {
-		fmt.Println("error fetching min gas price")
-		return nil, &types.Error{
-			Code:      0,
-			Message:   err.Error(),
-			Retriable: true,
-		}
-	}
-
-	preProcessResp.Options[rosettaUtil.GAS_PRICE] = minGasPrice
+	preProcessResp.Options[rosettaUtil.GAS_PRICE] = rosettaUtil.GAS_PRICE
 	preProcessResp.Options[rosettaUtil.GAS_LIMIT] = rosettaUtil.GAS_LIMIT_VALUE
 	return preProcessResp, nil
 }

--- a/server/services/construction_service.go
+++ b/server/services/construction_service.go
@@ -13,13 +13,11 @@ const (
 )
 
 type ConstructionAPIService struct {
-	Config         *config.Config
-	MemPoolService *MemoryPoolAPIService
+	Config *config.Config
 }
 
-func NewConstructionAPIService(config *config.Config, memPoolService *MemoryPoolAPIService) *ConstructionAPIService {
+func NewConstructionAPIService(config *config.Config) *ConstructionAPIService {
 	return &ConstructionAPIService{
-		Config:         config,
-		MemPoolService: memPoolService,
+		Config: config,
 	}
 }

--- a/server/services/construction_submit.go
+++ b/server/services/construction_submit.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+
 	"github.com/Zilliqa/gozilliqa-sdk/provider"
 	"github.com/Zilliqa/gozilliqa-sdk/transaction"
 	goZilUtil "github.com/Zilliqa/gozilliqa-sdk/util"
@@ -32,15 +34,13 @@ func (c *ConstructionAPIService) ConstructionSubmit(
 	}
 	txn := transaction.NewFromPayload(pl)
 
-	fmt.Printf("/submit - txn: %v\n\n", txn)
-
 	// txn.ToAddr should be in zil format
 	// New.FromPayload adds uneeded '0x' prefix
 	// remove uneeded 0x prefix
 	// convert to checksum format
 	txn.ToAddr = rosettaUtil.ToChecksumAddr(rosettaUtil.RemoveHexPrefix(txn.ToAddr))
 
-	fmt.Printf("/submit - txn: %v\n\n", txn.ToAddr)
+	fmt.Printf("/submit - txn recipient: %v\n\n", txn.ToAddr)
 
 	hash, err1 := txn.Hash()
 	if err1 != nil {
@@ -55,13 +55,31 @@ func (c *ConstructionAPIService) ConstructionSubmit(
 	hexHash := goZilUtil.EncodeHex(hash)
 	txn.ID = hexHash
 
-	err2 := c.MemPoolService.AddTransaction(ctx, request.NetworkIdentifier, txn)
-	if err2 != nil {
-		fmt.Println("error trying to add transaction")
+	// send transaction
+	api := c.Config.NodeAPI(request.NetworkIdentifier.Network)
+	rpcClient := provider.NewProvider(api)
+
+	t, _ := rpcClient.GetTransaction(txn.ID)
+
+	if t != nil && t.ID != "" {
 		return nil, &types.Error{
 			Code:      0,
-			Message:   err2.Error(),
+			Message:   "transaction already sent and confirmed",
 			Retriable: false,
+		}
+	}
+
+	payload := txn.ToTransactionPayload()
+	payloadJSON, _ := json.Marshal(payload)
+	fmt.Println(string(payloadJSON))
+
+	createTxnResp, err2 := rpcClient.CreateTransaction(payload)
+
+	if err2 != nil || createTxnResp.Error != nil {
+		return nil, &types.Error{
+			Code:      0,
+			Message:   createTxnResp.Error.Error(),
+			Retriable: true,
 		}
 	}
 

--- a/server/services/mempool_service.go
+++ b/server/services/mempool_service.go
@@ -1,5 +1,9 @@
 package services
 
+// @deprecated due to disabling of GetPendingTxns since Zilliqa V8.0.0
+// https://github.com/Zilliqa/Zilliqa/releases/tag/v8.0.0
+// https://www.rosetta-api.org/docs/all_methods.html
+
 import (
 	"context"
 	"encoding/json"
@@ -69,6 +73,7 @@ func (m *MemoryPoolAPIService) AddTransaction(ctx context.Context, network *type
 	}
 }
 
+// @deprecated
 func (m *MemoryPoolAPIService) Mempool(ctx context.Context, req *types.NetworkRequest) (*types.MempoolResponse,
 	*types.Error) {
 
@@ -115,6 +120,7 @@ func (m *MemoryPoolAPIService) Mempool(ctx context.Context, req *types.NetworkRe
 	return resp, nil
 }
 
+// @deprecated
 func (m *MemoryPoolAPIService) MempoolTransaction(ctx context.Context, req *types.MempoolTransactionRequest,
 ) (*types.MempoolTransactionResponse, *types.Error) {
 	hash := req.TransactionIdentifier.Hash

--- a/server/services/network_service.go
+++ b/server/services/network_service.go
@@ -166,7 +166,6 @@ func (s *NetworkAPIService) NetworkOptions(
 		config.ContractAddressError,
 		config.PreExecuteError,
 		config.QueryBalanceError,
-		config.TxNotExistInMem,
 		config.HeightHistoricalLessThanCurrent,
 		config.StoreDbError,
 		config.PublicHexError,

--- a/testnet.config.local.yaml
+++ b/testnet.config.local.yaml
@@ -1,7 +1,7 @@
 rosetta:
  host: "0.0.0.0"
  port: 8080
- version: "1.4.9"
+ version: "1.4.10"
  middleware_version: "0.0.1"
 
 networks:

--- a/util/utils.go
+++ b/util/utils.go
@@ -30,7 +30,7 @@ const (
 	Base16          = "base16"
 	VERSION         = "version"
 	SENDER_ADDR     = "senderAddr"
-	GAS_LIMIT_VALUE = "1"
+	GAS_LIMIT_VALUE = "50"
 	GAS_PRICE_VALUE = "2000000000"
 
 	// others


### PR DESCRIPTION
- update rosetta sdk to 0.70
- update rosetta api to 1.4.10
- supports rosetta-cli 0.7.1
- remove `/mempool/*` api
- fix `/construction/submit` after mempool is deprecated
- fix gas limit
- add tests end conditions
- minor refactorings